### PR TITLE
Use Crystal 1.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   lint:
     name: Spec
     runs-on: ubuntu-20.04
-    container: crystallang/crystal:1.0.0
+    container: crystallang/crystal:1.1.0
 
     steps:
       - name: Checkout
@@ -17,7 +17,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Shards install
-        run: shards install --ignore-crystal-version
+        run: shards install
 
       - name: Spec
         run: crystal spec --no-color --order random

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           wget https://crystal-lang.org/install.sh
           chmod +x install.sh
-          sudo ./install.sh --crystal=1.0.0
+          sudo ./install.sh --crystal=1.1.1
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: crystal
-
-# Uncomment the following if you'd like Travis to run specs and check code formatting
-# script:
-#   - crystal spec
-#   - crystal tool format --check

--- a/build/cross-compile-with-docker
+++ b/build/cross-compile-with-docker
@@ -19,11 +19,6 @@ docker run --rm --platform arm64 -v "$PWD":/work -i "$image" /bin/bash << EOF
 set -eux
 apt-get update
 apt-get install -y wget clang libssl-dev libpcre3-dev libgc-dev libevent-dev zlib1g-dev
-wget https://raw.githubusercontent.com/crystal-lang/crystal/1.0.0/src/ext/sigfault.c
-cc -c -o sigfault.o sigfault.c
-ar -rcs libcrystal.a sigfault.o
-mkdir -p /usr/share/crystal/src/ext
-cp libcrystal.a /usr/share/crystal/src/ext/
 
 cd /work
 cc -Wall -O3 -c lib/fdpass/src/fdpass.c -o lib/fdpass/src/fdpass.o

--- a/shard.yml
+++ b/shard.yml
@@ -16,6 +16,6 @@ dependencies:
   fdpass:
     github: 84codes/fdpass.cr
 
-crystal: 1.0.0
+crystal: 1.1.1
 
 license: MIT


### PR DESCRIPTION
I noticed that CI failed because it couldn't find 1.0.0:
https://github.com/84codes/sparoid/runs/3166205736?check_suite_focus=true#step:3:48

Apparently their new repo ("openSUSE Build Service") will only host the latest release:
https://github.com/crystal-lang/crystal/issues/10949#issuecomment-881310275

...but there's no Docker image for 1.1.1 right now.

Also no need to compile src/ext/sigfault.c since https://github.com/crystal-lang/crystal/pull/10463