### PR TITLE
No IP check

### DIFF
--- a/src/server.cr
+++ b/src/server.cr
@@ -34,7 +34,7 @@ module Sparoid
           verify_ts(msg.ts)
           ip_str = ip_to_s(msg.ip)
           verify_nounce(msg.nounce)
-          puts "#{client_addr} packet accepted"
+          puts "#{client_addr} packet accepted #{ip_str != client_addr ? "ip=#{ip_str}" : ""}"
           spawn open_then_close(ip_str)
         rescue ex
           puts "#{client_addr} ERROR: #{ex.message}"

--- a/src/server.cr
+++ b/src/server.cr
@@ -33,7 +33,6 @@ module Sparoid
           msg = Message.from_io(plain, IO::ByteFormat::NetworkEndian)
           verify_ts(msg.ts)
           ip_str = ip_to_s(msg.ip)
-          verify_ip(ip_str, client_addr)
           verify_nounce(msg.nounce)
           puts "#{client_addr} packet accepted"
           spawn open_then_close(ip_str)
@@ -83,10 +82,6 @@ module Sparoid
           str << part
         end
       end
-    end
-
-    private def verify_ip(ip_str, client_addr)
-      ip_str == client_addr.address || raise "source ip doesn't match"
     end
 
     private def verify_packet(data : Bytes) : Bytes


### PR DESCRIPTION
By not checking that the IP in the package matches the IP that sent the package, one party can open ports for third party. As the package is still nounce protected it shouldn't be any reply attack possibility. 