### PR TITLE
Dont set MemoryHigh in systemd

### DIFF
--- a/build/deb
+++ b/build/deb
@@ -91,7 +91,6 @@ ExecStart=/usr/bin/sparoid-server --config /etc/sparoid.ini
 Restart=always
 ProtectSystem=full
 MemoryAccounting=true
-MemoryHigh=4M
 MemoryMax=32M
 
 [Install]

--- a/extras/sparoid-server.service
+++ b/extras/sparoid-server.service
@@ -9,7 +9,6 @@ ExecStart=/usr/sbin/sparoid-server --config /etc/sparoid.ini
 Restart=always
 ProtectSystem=strict
 MemoryAccounting=true
-MemoryHigh=4M
 MemoryMax=32M
 
 [Install]


### PR DESCRIPTION
Sparoid appears to hang on the function call related to MemoryHigh when the server is running out of memory. Better to rely on MemoryMax which actually kills the process and restarts it afterwards
