### PR TITLE
Ameba: Handle `Naming/BlockParameterName`

### DIFF
--- a/src/client-cli.cr
+++ b/src/client-cli.cr
@@ -8,7 +8,7 @@ port = 8484
 tcp_port = 22
 config_path = "~/.sparoid.ini"
 
-parser = OptionParser.new do |p|
+parser = OptionParser.new do |p| # ameba:disable Naming/BlockParameterName
   p.banner = "Usage: #{PROGRAM_NAME} [subcommand] [arguments]"
   p.invalid_option do |flag|
     STDERR.puts "ERROR: #{flag} is not a valid option."

--- a/src/client.cr
+++ b/src/client.cr
@@ -14,7 +14,7 @@ module Sparoid
       hmac_key = ENV.fetch("SPAROID_HMAC_KEY", "")
       config_path = File.expand_path config_path, home: true
       if File.exists? config_path
-        config = File.open(config_path) { |f| INI.parse(f) }
+        config = File.open(config_path) { |file| INI.parse(file) }
         config.each do |_, section|
           section.each do |k, v|
             case k

--- a/src/config.cr
+++ b/src/config.cr
@@ -40,10 +40,10 @@ module Sparoid
     end
 
     private def parse_config
-      File.open(@config_file) do |f|
+      File.open(@config_file) do |file|
         @keys.clear
         @hmac_keys.clear
-        INI.parse(f).each do |_, values|
+        INI.parse(file).each do |_, values|
           # ignore sections, assume there's only the empty
           values.each do |k, v|
             case k

--- a/src/public_ip.cr
+++ b/src/public_ip.cr
@@ -69,20 +69,20 @@ module Sparoid
     end
 
     private def self.read_cache : StaticArray(UInt8, 4)
-      File.open(CACHE_PATH, "r") do |f|
-        f.flock_shared
-        str_to_arr(f.gets_to_end)
+      File.open(CACHE_PATH, "r") do |file|
+        file.flock_shared
+        str_to_arr(file.gets_to_end)
       end
     end
 
     private def self.write_cache(& : -> StaticArray(UInt8, 4)) : StaticArray(UInt8, 4)
-      File.open(CACHE_PATH, "a", 0o0644) do |f|
-        f.flock_exclusive
+      File.open(CACHE_PATH, "a", 0o0644) do |file|
+        file.flock_exclusive
         ip = yield
-        f.truncate
+        file.truncate
         ip.each_with_index do |e, i|
-          f.print '.' unless i.zero?
-          f.print e
+          file.print '.' unless i.zero?
+          file.print e
         end
         ip
       end


### PR DESCRIPTION
### WHY are these changes introduced?

CI fails as Ameba runs on 1.6.1 and the rule was added in 1.6.0:

https://github.com/crystal-ameba/ameba/releases/tag/v1.6.0

### WHAT is this pull request doing?

Taking care of `Naming/BlockParameterName` offenses. Decided to not change the `p` as `parser` is already taken in scope and `option_parser` just felt worse than the disabling (disable also affects less lines).

### HOW can this pull request be tested?

Specs