### PR TITLE
`bzip2` not installed in builder images for Ubuntu 24.04 and Debian 12

### DIFF
--- a/deb.dockerfile
+++ b/deb.dockerfile
@@ -1,6 +1,8 @@
 ARG build_image
 FROM $build_image AS build-stage
 
+RUN command -v bzip2 || (apt-get update && apt-get install bzip2 -y)
+
 # build static libmnl
 WORKDIR /tmp/libmnl
 RUN curl -sL https://www.netfilter.org/pub/libmnl/libmnl-1.0.5.tar.bz2 | tar jx --strip-components=1 && \

--- a/deb.dockerfile
+++ b/deb.dockerfile
@@ -1,7 +1,7 @@
 ARG build_image
 FROM $build_image AS build-stage
 
-RUN command -v bzip2 || (apt-get update && apt-get install bzip2 -y)
+RUN apt-get update && apt-get install bzip2 --yes
 
 # build static libmnl
 WORKDIR /tmp/libmnl


### PR DESCRIPTION
### WHY are these changes introduced?

Building [fails on Ubuntu 24.04](https://github.com/84codes/sparoid/actions/runs/10559396287/job/29250803583) and Debian 12 since we do not have `bzip2` installed in the respective builder.

### WHAT is this pull request doing?

Installing `bzip2`.

### HOW can this pull request be tested?

If it build, it works. Tested locally with `docker build --progress=plain --build-arg build_image=84codes/crystal:latest-debian-12 -f deb.dockerfile .`