### PR TITLE
Fix building Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 84codes/crystal:latest-alpine as builder
+FROM 84codes/crystal:latest-alpine AS builder
 RUN apk add --no-cache nftables-dev libnftnl-dev libmnl-dev
 WORKDIR /tmp
 COPY shard.yml shard.lock ./
@@ -7,6 +7,6 @@ COPY src/ src/
 RUN shards build --release --production --no-debug && strip bin/*
 
 FROM alpine:latest
-RUN apk add --no-cache libgcc libevent pcre libssl1.1 nftables
+RUN apk add --no-cache libgcc libevent pcre2 libssl3 nftables
 COPY --from=builder /tmp/bin/* /usr/bin/
 ENTRYPOINT ["/usr/bin/sparoid-server"]


### PR DESCRIPTION
### WHY are these changes introduced?

The `libssl1.1` package does not exist in latest Alpine.

`84codes/crystal:latest-alpine` builds using ssl3 and pcre2 since https://github.com/84codes/crystal-container-images/commit/7caa059a35b6577414aa2dbad58996cccb98e6cf and https://github.com/84codes/crystal-container-images/commit/46aa4ea1ed9fde892f3a56a3d7925b3f66200436 respectively.

### WHAT is this pull request doing?

Using `libssl3` and `pcre2` instead of `libssl1.1` and `pcre`.

Also fixes the warning: `- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)`

### HOW can this pull request be tested?

`docker build .`