### PR TITLE
Use `dpkg-shlibdeps` to generate dependency list for Debian package

### DIFF
--- a/build/deb
+++ b/build/deb
@@ -11,6 +11,13 @@ shards build --production --release --no-debug sparoid-server
 shards build --production --release --no-debug -Dgc_none sparoid
 strip bin/*
 
+# dpkg-shlibdeps requires presence of `debian/control`
+apt-get update && apt-get install dpkg-dev --yes
+mkdir debian
+touch debian/control
+shlib_depends=$(dpkg-shlibdeps -O -e bin/* 2> /dev/null);
+depends=${shlib_depends#shlibs:Depends=}
+rm -r debian
 
 mkdir debroot
 cd debroot
@@ -107,7 +114,7 @@ Homepage: https://github.com/84codes/sparoid
 Section: net
 Priority: optional
 Architecture: $architecture
-Depends: $(ldd ../bin/* | awk '/=>/ {print $1}' | xargs dpkg -S | awk -F: "/$architecture/ { print \$1 }" | sort -u | paste -sd,)
+Depends: $depends
 Installed-Size: $(du -ks usr/ | cut -f 1)
 Maintainer: 84codes <contact@84codes.com>
 Description: Single Packet Authorization


### PR DESCRIPTION
### WHY are these changes introduced?

The old way of doing it would mistakingly add `libc6-dev` as a dependency to sparoid under Ubuntu Noble (24.04) and Debian Bookworm (12).

This is the 'same' change as in cloudamqp/websocket-tcp-relay#21

### WHAT is this pull request doing?

Using `dpkg-shlibdeps` to generate dependency list for the Debian package.

### HOW can this pull request be tested?

Built Ubuntu 18.04/24.04 and Debian 10/12 locally and inspected the generated `Depends:` line (added after `build/deb` step: `RUN dpkg -I $(find . -name *.deb)`).

Also manually installed the 24.04 package on a 24.04 machine, and 22.04 respectively seems to work fine.