### PR TITLE
Bump GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container: 84codes/crystal:latest-alpine
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Shards install
         run: shards install --production
       - name: Spec
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     container: 84codes/crystal:latest-alpine
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Format check
         run: crystal tool format --check
   lint:
@@ -34,7 +34,7 @@ jobs:
       - name: Install make
         run: apk add --no-cache make yaml-dev
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Shards install
         run: shards install
       - name: Spec
@@ -44,7 +44,7 @@ jobs:
     needs: [spec, format, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker/metadata-action@v3
         id: meta
         with:
@@ -77,7 +77,7 @@ jobs:
         arch: [amd64, arm64]
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, debian-10, debian-11, debian-12]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - uses: docker/build-push-action@v3
@@ -91,9 +91,9 @@ jobs:
             build_image=84codes/crystal:latest-${{ matrix.os }}
           outputs: builds
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: debs
+          name: deb-${{ matrix.arch }}-${{ matrix.os }}
           path: builds/
       - name: Upload to PackageCloud
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -119,7 +119,7 @@ jobs:
         os: [fedora-39, fedora-40]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - uses: docker/build-push-action@v3
@@ -132,9 +132,9 @@ jobs:
             build_image=84codes/crystal:latest-${{ matrix.os }}
           outputs: builds
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: rpms
+          name: rpm-${{ matrix.arch }}-${{ matrix.os }}
           path: builds/
       - name: Upload to PackageCloud
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [spec, format, lint]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - name: Build tar package
@@ -165,7 +165,7 @@ jobs:
           cache-to: type=gha,mode=max
           outputs: .
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tar
           path: ./*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,21 +45,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/metadata-action@v3
+      - uses: docker/metadata-action@v5
         id: meta
         with:
           images: 84codes/sparoid
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=ref,event=tag
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/login-action@v2
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push container
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
@@ -78,9 +78,9 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, debian-10, debian-11, debian-12]
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/build-push-action@v3
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
         name: Build
         with:
           file: deb.dockerfile
@@ -120,9 +120,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/build-push-action@v3
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
         with:
           file: rpm.dockerfile
           platforms: linux/${{ matrix.arch }}
@@ -155,10 +155,10 @@ jobs:
     needs: [spec, format, lint]
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - name: Build tar package
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: tar.dockerfile
           cache-from: type=gha

--- a/tar.dockerfile
+++ b/tar.dockerfile
@@ -1,4 +1,4 @@
-FROM 84codes/crystal:1.5.0-alpine-latest as build-stage
+FROM 84codes/crystal:1.5.0-alpine-latest AS build-stage
 WORKDIR /tmp
 COPY shard.yml shard.lock README.md LICENSE ./
 RUN shards install --production


### PR DESCRIPTION
### WHY / WHAT are these changes introduced?

`upload-artifact@v3` is deprecated and will start with brownouts on Nov 14. We had tons of warnings from other actions, so decided to bump them all.

For `upload-artifact`, there are breaking changes https://github.com/actions/upload-artifact/blob/v4.4.3/docs/MIGRATION.md, so we had to use unique names.

Couldn't spot anything breaking for other bumps (doesn't mean there aren't any though)

### HOW can this pull request be tested?

If CI runs well it covers most cases (from first glance, all of them).