### PR TITLE
Make sparoid able to bind on ::

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.2.0] - 2026-02-04
+## Unreleased
 
 - Server can bind on IPv6 addresses (e.g., `::` to accept both IPv4 and IPv6 connections)
 - Breaking (library API only): `Server.new` now requires an `address` parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.2.0] - 2026-02-04
+
+- Server can bind on IPv6 addresses (e.g., `::` to accept both IPv4 and IPv6 connections)
+- Breaking (library API only): `Server.new` now requires an `address` parameter
+- Breaking (library API only): `Server.bind` no longer takes arguments
+
+Note: The breaking changes only affect usage of the `Server` class in Crystal code, not the built application interface.
+
 ## [1.1.13] - 2024-09-25
 
 - Lookup public IP by HTTP instead of DNS

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: sparoid
-version: 1.2.0
+version: 1.1.13
 
 authors:
   - 84codes <contact@84codes.com>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: sparoid
-version: 1.1.13
+version: 1.2.0
 
 authors:
   - 84codes <contact@84codes.com>

--- a/spec/sparoid_spec.cr
+++ b/spec/sparoid_spec.cr
@@ -2,19 +2,17 @@ require "./spec_helper"
 
 KEYS      = Array(String).new(2) { Random::Secure.hex(32) }
 HMAC_KEYS = Array(String).new(2) { Random::Secure.hex(32) }
-HOST      = "127.0.0.1"
-PORT      = 8484
-ADDRESS   = Socket::IPAddress.new(HOST, PORT)
+ADDRESS   = Socket::IPAddress.new("127.0.0.1", 8484)
 
 describe Sparoid::Server do
   it "works" do
     last_ip = nil
     cb = ->(ip : String) { last_ip = ip }
-    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS.family)
-    s.bind(ADDRESS)
+    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS)
+    s.bind
     spawn s.listen
     s.@seen_nounces.size.should eq 0
-    Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, HOST, PORT)
+    Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, ADDRESS.address, ADDRESS.port)
     Fiber.yield
     s.@seen_nounces.size.should eq 1
     last_ip.should eq "127.0.0.1"
@@ -24,11 +22,11 @@ describe Sparoid::Server do
 
   it "fails invalid packet lengths" do
     cb = ->(ip : String) { ip.should be_nil }
-    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS.family)
-    s.bind(ADDRESS)
+    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS)
+    s.bind
     spawn s.listen
     socket = UDPSocket.new
-    socket.connect HOST, PORT
+    socket.connect ADDRESS.address, ADDRESS.port
     socket.send Bytes.new(8)
     socket.close
     Fiber.yield
@@ -39,11 +37,11 @@ describe Sparoid::Server do
 
   it "fails invalid key" do
     cb = ->(ip : String) { ip.should be_nil }
-    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS.family)
-    s.bind(ADDRESS)
+    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS)
+    s.bind
     spawn s.listen
     invalid_key = Random::Secure.hex(32)
-    Sparoid::Client.send(invalid_key, HMAC_KEYS.first, HOST, PORT)
+    Sparoid::Client.send(invalid_key, HMAC_KEYS.first, ADDRESS.address, ADDRESS.port)
     Fiber.yield
     s.@seen_nounces.size.should eq 0
   ensure
@@ -52,11 +50,11 @@ describe Sparoid::Server do
 
   it "fails invalid hmac key" do
     cb = ->(ip : String) { ip.should be_nil }
-    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS.family)
-    s.bind(ADDRESS)
+    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS)
+    s.bind
     spawn s.listen
     invalid_hmac_key = Random::Secure.hex(32)
-    Sparoid::Client.send(KEYS.first, invalid_hmac_key, HOST, PORT)
+    Sparoid::Client.send(KEYS.first, invalid_hmac_key, ADDRESS.address, ADDRESS.port)
     Fiber.yield
     s.@seen_nounces.size.should eq 0
   ensure
@@ -66,12 +64,12 @@ describe Sparoid::Server do
   it "client can cache IP" do
     accepted = 0
     cb = ->(_ip : String) { accepted += 1 }
-    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS.family)
-    s.bind(ADDRESS)
+    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS)
+    s.bind
     spawn s.listen
     s.@seen_nounces.size.should eq 0
     c = Sparoid::Client.new(KEYS.first, HMAC_KEYS.first)
-    c.send(HOST, PORT)
+    c.send(ADDRESS.address, ADDRESS.port)
     Fiber.yield
     s.@seen_nounces.size.should eq 1
     accepted.should eq 1
@@ -82,12 +80,12 @@ describe Sparoid::Server do
   it "works with two keys" do
     accepted = 0
     cb = ->(_ip : String) { accepted += 1 }
-    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS.family)
-    s.bind(ADDRESS)
+    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS)
+    s.bind
     spawn s.listen
     s.@seen_nounces.size.should eq 0
-    Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, HOST, PORT)
-    Sparoid::Client.send(KEYS.last, HMAC_KEYS.last, HOST, PORT)
+    Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, ADDRESS.address, ADDRESS.port)
+    Sparoid::Client.send(KEYS.last, HMAC_KEYS.last, ADDRESS.address, ADDRESS.port)
     Fiber.yield
     s.@seen_nounces.size.should eq 2
     accepted.should eq 2
@@ -98,11 +96,11 @@ describe Sparoid::Server do
   it "client can send another IP" do
     last_ip = nil
     cb = ->(ip : String) { last_ip = ip }
-    address = Socket::IPAddress.new("0.0.0.0", PORT)
-    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, address.family)
-    s.bind(address)
+    address = Socket::IPAddress.new("0.0.0.0", ADDRESS.port)
+    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, address)
+    s.bind
     spawn s.listen
-    Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, "0.0.0.0", PORT, StaticArray[1u8, 1u8, 1u8, 1u8])
+    Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, "0.0.0.0", address.port, StaticArray[1u8, 1u8, 1u8, 1u8])
     Fiber.yield
     s.@seen_nounces.size.should eq 1
     last_ip.should eq "1.1.1.1"
@@ -113,11 +111,11 @@ describe Sparoid::Server do
   it "can accept IPv4 connections on ::" do
     last_ip = nil
     cb = ->(ip : String) { last_ip = ip }
-    address = Socket::IPAddress.new("::", PORT)
-    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, address.family)
-    s.bind(address)
+    address = Socket::IPAddress.new("::", ADDRESS.port)
+    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, address)
+    s.bind
     spawn s.listen
-    Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, "127.0.0.1", PORT)
+    Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, "127.0.0.1", address.port)
     Fiber.yield
     s.@seen_nounces.size.should eq 1
     last_ip.should eq "127.0.0.1"

--- a/src/server-cli.cr
+++ b/src/server-cli.cr
@@ -28,8 +28,8 @@ begin
     }
   end
   address = Socket::IPAddress.new(c.host, c.port)
-  s = Sparoid::Server.new(c.keys, c.hmac_keys, on_accept, address.family)
-  s.bind(address)
+  s = Sparoid::Server.new(c.keys, c.hmac_keys, on_accept, address)
+  s.bind
   s.listen
 rescue ex
   STDERR.puts "ERROR: #{ex.message}"

--- a/src/server-cli.cr
+++ b/src/server-cli.cr
@@ -1,3 +1,4 @@
+require "socket"
 require "./server"
 require "./config"
 require "./nftables"
@@ -26,8 +27,9 @@ begin
       end
     }
   end
-  s = Sparoid::Server.new(c.keys, c.hmac_keys, on_accept)
-  s.bind(c.host, c.port)
+  address = Socket::IPAddress.new(c.host, c.port)
+  s = Sparoid::Server.new(c.keys, c.hmac_keys, on_accept, address.family)
+  s.bind(address)
   s.listen
 rescue ex
   STDERR.puts "ERROR: #{ex.message}"

--- a/src/server.cr
+++ b/src/server.cr
@@ -8,16 +8,16 @@ module Sparoid
     @keys : Array(Bytes)
     @hmac_keys : Array(Bytes)
 
-    def initialize(keys : Enumerable(String), hmac_keys : Enumerable(String), @on_accept : Proc(String, Nil))
+    def initialize(keys : Enumerable(String), hmac_keys : Enumerable(String), @on_accept : Proc(String, Nil), family : Socket::Family)
       @keys = keys.map &.hexbytes
       @hmac_keys = hmac_keys.map &.hexbytes
       raise ArgumentError.new("Key must be 32 bytes hex encoded") if @keys.any? { |k| k.bytesize != 32 }
       raise ArgumentError.new("HMAC key must be 32 bytes hex encoded") if @hmac_keys.any? { |k| k.bytesize != 32 }
-      @socket = UDPSocket.new
+      @socket = UDPSocket.new(family)
     end
 
-    def bind(host, port)
-      @socket.bind host, port
+    def bind(address : Socket::IPAddress)
+      @socket.bind address
     end
 
     def listen

--- a/src/server.cr
+++ b/src/server.cr
@@ -8,16 +8,16 @@ module Sparoid
     @keys : Array(Bytes)
     @hmac_keys : Array(Bytes)
 
-    def initialize(keys : Enumerable(String), hmac_keys : Enumerable(String), @on_accept : Proc(String, Nil), family : Socket::Family)
+    def initialize(keys : Enumerable(String), hmac_keys : Enumerable(String), @on_accept : Proc(String, Nil), @address : Socket::IPAddress)
       @keys = keys.map &.hexbytes
       @hmac_keys = hmac_keys.map &.hexbytes
       raise ArgumentError.new("Key must be 32 bytes hex encoded") if @keys.any? { |k| k.bytesize != 32 }
       raise ArgumentError.new("HMAC key must be 32 bytes hex encoded") if @hmac_keys.any? { |k| k.bytesize != 32 }
-      @socket = UDPSocket.new(family)
+      @socket = UDPSocket.new(@address.family)
     end
 
-    def bind(address : Socket::IPAddress)
-      @socket.bind address
+    def bind
+      @socket.bind @address
     end
 
     def listen


### PR DESCRIPTION
### WHY are these changes introduced?
Sparoid-server will crash if instructed to bind to `::`

### WHAT is this pull request doing?

Make sparoid able to bind to `::`

### HOW was this pull request tested?
Manually by starting a server with `::` and `127.0.0.1` without a crash.

<!---

Friendly reminders

- Write documentation (Internal, API, Website)
- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)

-->
