### PR TITLE
We should not parse unexpected message versions

### DIFF
--- a/spec/sparoid_spec.cr
+++ b/spec/sparoid_spec.cr
@@ -122,4 +122,17 @@ describe Sparoid::Server do
   ensure
     s.try &.close
   end
+
+  it "raises on unsupported message version" do
+    ts = Time.utc.to_unix_ms
+    nounce = StaticArray(UInt8, 16).new(0_u8)
+    Random::Secure.random_bytes(nounce.to_slice)
+    msg = Sparoid::Message.new(2, ts, nounce, StaticArray[127u8, 0u8, 0u8, 1u8])
+
+    msg.to_slice(IO::ByteFormat::NetworkEndian).tap do |slice|
+      expect_raises(Exception, "Unsupported message version: 2") do
+        Sparoid::Message.from_io(IO::Memory.new(slice), IO::ByteFormat::NetworkEndian)
+      end
+    end
+  end
 end

--- a/src/message.cr
+++ b/src/message.cr
@@ -32,6 +32,9 @@ module Sparoid
 
     def self.from_io(io, format)
       version = Int32.from_io(io, format)
+      if version != 1
+        raise "Unsupported message version: #{version}"
+      end
       ts = Int64.from_io(io, format)
       nounce = uninitialized UInt8[16]
       io.read_fully(nounce.to_slice)


### PR DESCRIPTION
### WHY are these changes introduced?
We should only parse explicit message versions.

### WHAT is this pull request doing?
Raises an error on a message version that is unexpected.

### HOW was this pull request tested?

Specs

<!---

Friendly reminders

- Write documentation (Internal, API, Website)
- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)

-->
