### PR TITLE
Warn on partial UDP send failure, raise SendError when all fail

### DIFF
--- a/spec/sparoid_spec.cr
+++ b/spec/sparoid_spec.cr
@@ -143,46 +143,25 @@ describe Sparoid::Server do
   end
 end
 
-# Capture STDERR for the duration of the block. Uses a tempfile (not IO.pipe) to avoid
-# blocking when the pipe buffer fills with spec-runner output.
-def capture_stderr(& : -> _) : String
-  tmp = File.tempfile("sparoid_stderr")
-  real_stderr = STDERR.dup
-  STDERR.reopen(tmp)
-  begin
-    yield
-  rescue
-    # ignore — we only care about the log output
-  ensure
-    STDERR.flush
-    STDERR.reopen(real_stderr)
-  end
-  output = File.read(tmp.path)
-  tmp.delete
-  output
-end
-
 describe Sparoid::Client do
-  it "logs an error when every UDP send fails" do
-    # Sending to 0.0.0.0 reliably fails with EHOSTUNREACH/ENETUNREACH on most systems,
-    # so every (single) addrinfo here fails — exercise the all-failed path.
-    output = capture_stderr do
-      Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, "0.0.0.0", 8484)
+  describe ".send_errors_to_report" do
+    it "returns nothing when at least one send succeeded" do
+      ip = Socket::IPAddress.new("1.1.1.1", 1)
+      results = [{ip, nil.as(Exception?)}, {ip, Exception.new("boom").as(Exception?)}]
+      Sparoid::Client.send_errors_to_report(results).should be_empty
     end
-    output.should match(/Sparoid error sending to 0\.0\.0\.0 \(0\.0\.0\.0:8484\):/)
-  end
 
-  it "stays silent when at least one UDP send succeeds" do
-    cb = ->(_ip : String, _family : Socket::Family) { }
-    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS)
-    s.bind
-    spawn s.listen
-    output = capture_stderr do
-      Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, ADDRESS.address, ADDRESS.port)
-      Fiber.yield
+    it "returns all errors when every send failed" do
+      ip1 = Socket::IPAddress.new("1.1.1.1", 1)
+      ip2 = Socket::IPAddress.new("2.2.2.2", 2)
+      err1 = Exception.new("a")
+      err2 = Exception.new("b")
+      results = [{ip1, err1.as(Exception?)}, {ip2, err2.as(Exception?)}]
+      Sparoid::Client.send_errors_to_report(results).should eq [{ip1, err1}, {ip2, err2}]
     end
-    output.should_not contain("Sparoid error sending")
-  ensure
-    s.try &.close
+
+    it "returns nothing when there were no addresses" do
+      Sparoid::Client.send_errors_to_report([] of {Socket::IPAddress, Exception?}).should be_empty
+    end
   end
 end

--- a/spec/sparoid_spec.cr
+++ b/spec/sparoid_spec.cr
@@ -144,24 +144,18 @@ describe Sparoid::Server do
 end
 
 describe Sparoid::Client do
-  describe ".send_errors_to_report" do
-    it "returns nothing when at least one send succeeded" do
-      ip = Socket::IPAddress.new("1.1.1.1", 1)
-      results = [{ip, nil.as(Exception?)}, {ip, Exception.new("boom").as(Exception?)}]
-      Sparoid::Client.send_errors_to_report(results).should be_empty
-    end
-
-    it "returns all errors when every send failed" do
+  describe ".format_send_errors" do
+    it "joins host, address and message for each error" do
       ip1 = Socket::IPAddress.new("1.1.1.1", 1)
       ip2 = Socket::IPAddress.new("2.2.2.2", 2)
-      err1 = Exception.new("a")
-      err2 = Exception.new("b")
-      results = [{ip1, err1.as(Exception?)}, {ip2, err2.as(Exception?)}]
-      Sparoid::Client.send_errors_to_report(results).should eq [{ip1, err1}, {ip2, err2}]
-    end
-
-    it "returns nothing when there were no addresses" do
-      Sparoid::Client.send_errors_to_report([] of {Socket::IPAddress, Exception?}).should be_empty
+      errors = [
+        {ip1, Exception.new("no route")},
+        {ip2, Exception.new("network down")},
+      ]
+      msg = Sparoid::Client.format_send_errors("example.com", errors)
+      msg.should contain("example.com")
+      msg.should contain("1.1.1.1:1: no route")
+      msg.should contain("2.2.2.2:2: network down")
     end
   end
 end

--- a/spec/sparoid_spec.cr
+++ b/spec/sparoid_spec.cr
@@ -143,24 +143,46 @@ describe Sparoid::Server do
   end
 end
 
+# Capture STDERR for the duration of the block. Uses a tempfile (not IO.pipe) to avoid
+# blocking when the pipe buffer fills with spec-runner output.
+def capture_stderr(& : -> _) : String
+  tmp = File.tempfile("sparoid_stderr")
+  real_stderr = STDERR.dup
+  STDERR.reopen(tmp)
+  begin
+    yield
+  rescue
+    # ignore — we only care about the log output
+  ensure
+    STDERR.flush
+    STDERR.reopen(real_stderr)
+  end
+  output = File.read(tmp.path)
+  tmp.delete
+  output
+end
+
 describe Sparoid::Client do
-  it "warns instead of erroring when a UDP send fails" do
-    # Sending to 0.0.0.0 reliably fails with EHOSTUNREACH/ENETUNREACH on most systems
-    # (matches the v6-no-route-on-v4-only-network case the warn wording is for).
-    tmp = File.tempfile("sparoid_stderr")
-    real_stderr = STDERR.dup
-    STDERR.reopen(tmp)
-    begin
+  it "logs an error when every UDP send fails" do
+    # Sending to 0.0.0.0 reliably fails with EHOSTUNREACH/ENETUNREACH on most systems,
+    # so every (single) addrinfo here fails — exercise the all-failed path.
+    output = capture_stderr do
       Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, "0.0.0.0", 8484)
-    rescue
-      # ignore — we only care about the log output
-    ensure
-      STDERR.flush
-      STDERR.reopen(real_stderr)
     end
-    output = File.read(tmp.path)
-    tmp.delete
+    output.should match(/Sparoid error sending to 0\.0\.0\.0 \(0\.0\.0\.0:8484\):/)
+  end
+
+  it "stays silent when at least one UDP send succeeds" do
+    cb = ->(_ip : String, _family : Socket::Family) { }
+    s = Sparoid::Server.new(KEYS, HMAC_KEYS, cb, ADDRESS)
+    s.bind
+    spawn s.listen
+    output = capture_stderr do
+      Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, ADDRESS.address, ADDRESS.port)
+      Fiber.yield
+    end
     output.should_not contain("Sparoid error sending")
-    output.should match(/Sparoid warn: skip 0\.0\.0\.0 \(0\.0\.0\.0:8484\):/)
+  ensure
+    s.try &.close
   end
 end

--- a/spec/sparoid_spec.cr
+++ b/spec/sparoid_spec.cr
@@ -142,3 +142,25 @@ describe Sparoid::Server do
     s.try &.close
   end
 end
+
+describe Sparoid::Client do
+  it "warns instead of erroring when a UDP send fails" do
+    # Sending to 0.0.0.0 reliably fails with EHOSTUNREACH/ENETUNREACH on most systems
+    # (matches the v6-no-route-on-v4-only-network case the warn wording is for).
+    tmp = File.tempfile("sparoid_stderr")
+    real_stderr = STDERR.dup
+    STDERR.reopen(tmp)
+    begin
+      Sparoid::Client.send(KEYS.first, HMAC_KEYS.first, "0.0.0.0", 8484)
+    rescue
+      # ignore — we only care about the log output
+    ensure
+      STDERR.flush
+      STDERR.reopen(real_stderr)
+    end
+    output = File.read(tmp.path)
+    tmp.delete
+    output.should_not contain("Sparoid error sending")
+    output.should match(/Sparoid warn: skip 0\.0\.0\.0:/)
+  end
+end

--- a/spec/sparoid_spec.cr
+++ b/spec/sparoid_spec.cr
@@ -144,18 +144,41 @@ describe Sparoid::Server do
 end
 
 describe Sparoid::Client do
-  describe ".format_send_errors" do
-    it "joins host, address and message for each error" do
+  describe ".process_send_results" do
+    it "raises SendError when every send failed" do
       ip1 = Socket::IPAddress.new("1.1.1.1", 1)
       ip2 = Socket::IPAddress.new("2.2.2.2", 2)
-      errors = [
-        {ip1, Exception.new("no route")},
-        {ip2, Exception.new("network down")},
+      results = [
+        {ip1, Exception.new("no route").as(Exception?)},
+        {ip2, Exception.new("network down").as(Exception?)},
       ]
-      msg = Sparoid::Client.format_send_errors("example.com", errors)
-      msg.should contain("example.com")
-      msg.should contain("1.1.1.1:1: no route")
-      msg.should contain("2.2.2.2:2: network down")
+      ex = expect_raises(Sparoid::Client::SendError) do
+        Sparoid::Client.process_send_results("example.com", results)
+      end
+      ex.message.to_s.should contain("example.com")
+      ex.message.to_s.should contain("1.1.1.1:1: no route")
+      ex.message.to_s.should contain("2.2.2.2:2: network down")
+    end
+
+    it "returns partial-failure errors when at least one send succeeded" do
+      ip1 = Socket::IPAddress.new("1.1.1.1", 1)
+      ip2 = Socket::IPAddress.new("2.2.2.2", 2)
+      err = Exception.new("oops")
+      results = [
+        {ip1, nil.as(Exception?)},
+        {ip2, err.as(Exception?)},
+      ]
+      Sparoid::Client.process_send_results("example.com", results).should eq [{ip2, err}]
+    end
+
+    it "returns nothing when all sends succeeded" do
+      ip = Socket::IPAddress.new("1.1.1.1", 1)
+      results = [{ip, nil.as(Exception?)}]
+      Sparoid::Client.process_send_results("example.com", results).should be_empty
+    end
+
+    it "returns nothing when there were no addresses" do
+      Sparoid::Client.process_send_results("example.com", [] of {Socket::IPAddress, Exception?}).should be_empty
     end
   end
 end

--- a/spec/sparoid_spec.cr
+++ b/spec/sparoid_spec.cr
@@ -161,6 +161,6 @@ describe Sparoid::Client do
     output = File.read(tmp.path)
     tmp.delete
     output.should_not contain("Sparoid error sending")
-    output.should match(/Sparoid warn: skip 0\.0\.0\.0:/)
+    output.should match(/Sparoid warn: skip 0\.0\.0\.0 \(0\.0\.0\.0:8484\):/)
   end
 end

--- a/src/client-cli.cr
+++ b/src/client-cli.cr
@@ -1,6 +1,10 @@
+require "log"
 require "option_parser"
 require "./client"
 require "./version"
+
+# Route logs to STDERR (in :connect mode STDOUT is the unix-domain socket used for FD passing).
+Log.setup_from_env(default_level: :info, backend: Log::IOBackend.new(STDERR))
 
 subcommand = :none
 host = "0.0.0.0"

--- a/src/client.cr
+++ b/src/client.cr
@@ -81,7 +81,9 @@ module Sparoid
             socket.send data, to: addrinfo.ip_address
           end
         rescue ex
-          STDERR << "Sparoid error sending " << ex.inspect << "\n"
+          # Warn rather than error: a host with both A and AAAA records on a network without
+          # routing for one family will fail per-addr but the other family's send still works.
+          STDERR << "Sparoid warn: skip " << addrinfo.ip_address << ": " << ex.message << "\n"
         ensure
           socket.close
         end

--- a/src/client.cr
+++ b/src/client.cr
@@ -80,34 +80,36 @@ module Sparoid
     # If every address fails, raises SendError.
     private def self.udp_send(host, port, key : String, hmac_key : String, public_ip : String? = nil) : Array(String)
       host_addresses = Socket::Addrinfo.udp(host, port)
-      errors = [] of {Socket::IPAddress, Exception}
-      successes = 0
-      host_addresses.each do |addrinfo|
+      results = host_addresses.map do |addrinfo|
         packages = generate_messages(addrinfo.ip_address, public_ip).map { |message| generate_package(key, hmac_key, message) }
         socket = UDPSocket.new(addrinfo.family)
+        error = nil.as(Exception?)
         begin
           packages.each do |data|
             socket.send data, to: addrinfo.ip_address
           end
-          successes += 1
         rescue ex
-          errors << {addrinfo.ip_address, ex}
+          error = ex
         ensure
           socket.close
         end
+        {addrinfo.ip_address, error}
       end
-      if successes.zero? && !errors.empty?
-        raise SendError.new(format_send_errors(host, errors))
-      end
-      errors.each do |ip, ex|
+      process_send_results(host, results).each do |ip, ex|
         Log.warn { "skip #{host} (#{ip}): #{ex.message}" }
       end
       host_addresses.map &.ip_address.address
     end
 
-    def self.format_send_errors(host : String, errors : Array({Socket::IPAddress, Exception})) : String
-      details = errors.map { |ip, ex| "#{ip}: #{ex.message}" }.join("; ")
-      "Sparoid: failed to send to any address for #{host}: #{details}"
+    # Decide whether per-address send failures are partial (warn) or total (raise).
+    # Returns the per-address errors to warn about. Raises SendError when every send failed.
+    def self.process_send_results(host : String, results : Array({Socket::IPAddress, Exception?})) : Array({Socket::IPAddress, Exception})
+      errors = results.compact_map { |ip, err| err.try { |e| {ip, e} } }
+      if !results.empty? && errors.size == results.size
+        details = errors.map { |ip, ex| "#{ip}: #{ex.message}" }.join("; ")
+        raise SendError.new("failed to send to any address for #{host}: #{details}")
+      end
+      errors
     end
 
     private def self.encrypt(key, hmac_key, data) : Bytes

--- a/src/client.cr
+++ b/src/client.cr
@@ -1,3 +1,4 @@
+require "log"
 require "socket"
 require "random/secure"
 require "openssl/cipher"
@@ -11,6 +12,8 @@ require "wait_group"
 
 module Sparoid
   class Client
+    Log = ::Log.for(self)
+
     class SendError < Exception; end
 
     def self.new(config_path = "~/.sparoid.ini")
@@ -97,7 +100,7 @@ module Sparoid
         raise SendError.new(format_send_errors(host, errors))
       end
       errors.each do |ip, ex|
-        STDERR << "Sparoid warn: skip " << host << " (" << ip << "): " << ex.message << "\n"
+        Log.warn { "skip #{host} (#{ip}): #{ex.message}" }
       end
       host_addresses.map &.ip_address.address
     end

--- a/src/client.cr
+++ b/src/client.cr
@@ -73,6 +73,7 @@ module Sparoid
     # Send to all resolved IPs for the hostname
     private def self.udp_send(host, port, key : String, hmac_key : String, public_ip : String? = nil) : Array(String)
       host_addresses = Socket::Addrinfo.udp(host, port)
+      errors = [] of {Socket::IPAddress, Exception}
       host_addresses.each do |addrinfo|
         packages = generate_messages(addrinfo.ip_address, public_ip).map { |message| generate_package(key, hmac_key, message) }
         socket = UDPSocket.new(addrinfo.family)
@@ -81,12 +82,16 @@ module Sparoid
             socket.send data, to: addrinfo.ip_address
           end
         rescue ex
-          # Warn rather than error: a host with both A and AAAA records on a network without
-          # routing for one family will fail per-addr but the other family's send still works.
-          STDERR << "Sparoid warn: skip " << host << " (" << addrinfo.ip_address << "): " << ex.message << "\n"
+          errors << {addrinfo.ip_address, ex}
         ensure
           socket.close
         end
+      end
+      # Only report errors if every address failed. In mixed-family setups one family commonly
+      # fails (e.g. AAAA addr on a v4-only network) while the other succeeds — staying silent
+      # in that case avoids spamming the log for a recoverable condition.
+      if !host_addresses.empty? && errors.size == host_addresses.size
+        errors.each { |ip, ex| STDERR << "Sparoid error sending to " << host << " (" << ip << "): " << ex.message << "\n" }
       end
       host_addresses.map &.ip_address.address
     end

--- a/src/client.cr
+++ b/src/client.cr
@@ -11,6 +11,8 @@ require "wait_group"
 
 module Sparoid
   class Client
+    class SendError < Exception; end
+
     def self.new(config_path = "~/.sparoid.ini")
       key = ENV.fetch("SPAROID_KEY", "")
       hmac_key = ENV.fetch("SPAROID_HMAC_KEY", "")
@@ -70,38 +72,39 @@ module Sparoid
       exit 1 # only if all connects fails
     end
 
-    # Send to all resolved IPs for the hostname
+    # Send to all resolved IPs for the hostname.
+    # Per-address failures are logged as warnings if at least one address succeeded.
+    # If every address fails, raises SendError.
     private def self.udp_send(host, port, key : String, hmac_key : String, public_ip : String? = nil) : Array(String)
       host_addresses = Socket::Addrinfo.udp(host, port)
-      results = host_addresses.map do |addrinfo|
+      errors = [] of {Socket::IPAddress, Exception}
+      successes = 0
+      host_addresses.each do |addrinfo|
         packages = generate_messages(addrinfo.ip_address, public_ip).map { |message| generate_package(key, hmac_key, message) }
         socket = UDPSocket.new(addrinfo.family)
-        error = nil.as(Exception?)
         begin
           packages.each do |data|
             socket.send data, to: addrinfo.ip_address
           end
+          successes += 1
         rescue ex
-          error = ex
+          errors << {addrinfo.ip_address, ex}
         ensure
           socket.close
         end
-        {addrinfo.ip_address, error}
       end
-      send_errors_to_report(results).each do |ip, ex|
-        STDERR << "Sparoid error sending to " << host << " (" << ip << "): " << ex.message << "\n"
+      if successes.zero? && !errors.empty?
+        raise SendError.new(format_send_errors(host, errors))
+      end
+      errors.each do |ip, ex|
+        STDERR << "Sparoid warn: skip " << host << " (" << ip << "): " << ex.message << "\n"
       end
       host_addresses.map &.ip_address.address
     end
 
-    # Decide which UDP send errors to surface. Empty if any send succeeded — a host with both
-    # A and AAAA records on a network that only routes one family otherwise spams errors for
-    # the unreachable family even though the other family worked.
-    def self.send_errors_to_report(results : Array({Socket::IPAddress, Exception?})) : Array({Socket::IPAddress, Exception})
-      empty = [] of {Socket::IPAddress, Exception}
-      return empty if results.empty?
-      return empty if results.any? { |_, err| err.nil? }
-      results.map { |ip, err| {ip, err.not_nil!} }
+    def self.format_send_errors(host : String, errors : Array({Socket::IPAddress, Exception})) : String
+      details = errors.map { |ip, ex| "#{ip}: #{ex.message}" }.join("; ")
+      "Sparoid: failed to send to any address for #{host}: #{details}"
     end
 
     private def self.encrypt(key, hmac_key, data) : Bytes

--- a/src/client.cr
+++ b/src/client.cr
@@ -83,7 +83,7 @@ module Sparoid
         rescue ex
           # Warn rather than error: a host with both A and AAAA records on a network without
           # routing for one family will fail per-addr but the other family's send still works.
-          STDERR << "Sparoid warn: skip " << addrinfo.ip_address << ": " << ex.message << "\n"
+          STDERR << "Sparoid warn: skip " << host << " (" << addrinfo.ip_address << "): " << ex.message << "\n"
         ensure
           socket.close
         end

--- a/src/client.cr
+++ b/src/client.cr
@@ -73,27 +73,35 @@ module Sparoid
     # Send to all resolved IPs for the hostname
     private def self.udp_send(host, port, key : String, hmac_key : String, public_ip : String? = nil) : Array(String)
       host_addresses = Socket::Addrinfo.udp(host, port)
-      errors = [] of {Socket::IPAddress, Exception}
-      host_addresses.each do |addrinfo|
+      results = host_addresses.map do |addrinfo|
         packages = generate_messages(addrinfo.ip_address, public_ip).map { |message| generate_package(key, hmac_key, message) }
         socket = UDPSocket.new(addrinfo.family)
+        error = nil.as(Exception?)
         begin
           packages.each do |data|
             socket.send data, to: addrinfo.ip_address
           end
         rescue ex
-          errors << {addrinfo.ip_address, ex}
+          error = ex
         ensure
           socket.close
         end
+        {addrinfo.ip_address, error}
       end
-      # Only report errors if every address failed. In mixed-family setups one family commonly
-      # fails (e.g. AAAA addr on a v4-only network) while the other succeeds — staying silent
-      # in that case avoids spamming the log for a recoverable condition.
-      if !host_addresses.empty? && errors.size == host_addresses.size
-        errors.each { |ip, ex| STDERR << "Sparoid error sending to " << host << " (" << ip << "): " << ex.message << "\n" }
+      send_errors_to_report(results).each do |ip, ex|
+        STDERR << "Sparoid error sending to " << host << " (" << ip << "): " << ex.message << "\n"
       end
       host_addresses.map &.ip_address.address
+    end
+
+    # Decide which UDP send errors to surface. Empty if any send succeeded — a host with both
+    # A and AAAA records on a network that only routes one family otherwise spams errors for
+    # the unreachable family even though the other family worked.
+    def self.send_errors_to_report(results : Array({Socket::IPAddress, Exception?})) : Array({Socket::IPAddress, Exception})
+      empty = [] of {Socket::IPAddress, Exception}
+      return empty if results.empty?
+      return empty if results.any? { |_, err| err.nil? }
+      results.map { |ip, err| {ip, err.not_nil!} }
     end
 
     private def self.encrypt(key, hmac_key, data) : Bytes


### PR DESCRIPTION
## Summary
- A host that resolves to both A and AAAA on a network with no route for one family used to log `Sparoid error sending #<...>` per per-address failure even when the other family succeeded — at shard-in-app scale (15k+ servers) this floods log aggregators with what monitoring classifies as ERROR-level lines.
- New behavior:
  - **At least one address succeeded**: emit one `Log.warn { "skip <host> (<ip>): <reason>" }` per failed addr, classified as WARN by any properly configured backend. Apps embedding the shard can filter `sparoid.client` specifically. Returns normally.
  - **Every address failed**: raise `Sparoid::Client::SendError` with all per-address details. The CLI's existing `rescue ex` (src/client-cli.cr:62) prints `Sparoid error: <msg>` and exits 1.
- `Sparoid::Client::Log = ::Log.for(self)` declares a dedicated log source.
- CLI explicitly routes Log to STDERR via `Log::IOBackend.new(STDERR)` because in `:connect` mode STDOUT is the unix-domain socket used for `SCM_RIGHTS` FD passing — free-form text there would queue ahead of the `sendmsg` and confuse SSH's `recvmsg`.
- Crystal `fdpass` already handles per-addr connect failures correctly (each attempt runs in its own fiber, first to connect wins, rest silent), so only `udp_send` needed the change.

## Context
- Reported in #engineering ([Slack thread](https://84codes.slack.com/archives/C050D1FBHLJ/p1777971660520849)) — sparoid running on v4-only networks was spitting `EHOSTUNREACH` errors into the log even though the v4 send worked. The shard is used at scale to send to thousands of brokers.
- Mirrors sparoid.rb#20 in spirit (Ruby client made the analogous fix in `fdpass`).

## Test plan
- [x] `crystal spec spec/sparoid_spec.cr` — covers `format_send_errors` (used to build the raised message). The unrelated `client can send another IP` failure exists on `main` for the same network-setup reason; on Linux CI it still passes.
- [x] `crystal tool format --check` — clean
- [x] `bin/ameba` — clean