### PR TITLE
2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.2] - 2026-05-06
+- Client: warn (instead of error) on per-address UDP send failures when at least one address succeeds, so dual-stack hosts on single-family networks no longer log catastrophically
+- Client: raise `Sparoid::Client::SendError` when every address fails, surfacing a clear actionable failure
+- Client: partial-failure warnings now go through `Log.warn` (source `Sparoid::Client`) instead of raw STDERR
+
 ## [2.0.1] - 2026-04-29
 - Build for Ubuntu 26.04
 - Drops Ubuntu 20.04, Fedora 41

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: sparoid
-version: 2.0.1
+version: 2.0.2
 
 authors:
   - 84codes <contact@84codes.com>


### PR DESCRIPTION
## Summary
- Bumps `shard.yml` to `2.0.2`
- Adds `CHANGELOG.md` entry covering the partial-UDP-send fix from #23

## Release notes
- Client: warn (instead of error) on per-address UDP send failures when at least one address succeeds, so dual-stack hosts on single-family networks no longer log catastrophically
- Client: raise `Sparoid::Client::SendError` when every address fails, surfacing a clear actionable failure
- Client: partial-failure warnings now go through `Log.warn` (source `Sparoid::Client`) instead of raw STDERR

## Tagging
After merge, tag manually:
```
git tag v2.0.2 <merge-sha>
git push origin v2.0.2
```