### PR TITLE
Link deb build against the distro libnftables

### DIFF
--- a/deb.dockerfile
+++ b/deb.dockerfile
@@ -1,12 +1,6 @@
 ARG build_image
 FROM $build_image AS build-stage
 
-# Link against the distribution's libnftables rather than statically bundling
-# a pinned build. The bundled versions (nftables 1.0.5 / libnftnl 1.2.3 /
-# libmnl 1.0.5, pinned in 2022) segfault on Ubuntu 26.04, which ships nftables
-# 1.1.6: nft_run_cmd_from_buffer crashes as soon as it parses a ruleset created
-# by the newer userspace. Using the distro package keeps the linked library in
-# step with the nftables that is actually installed on the host.
 RUN apt-get update && apt-get install bzip2 libssl-dev libnftables-dev libnftnl-dev libmnl-dev --yes
 
 WORKDIR /tmp/sparoid

--- a/deb.dockerfile
+++ b/deb.dockerfile
@@ -1,28 +1,13 @@
 ARG build_image
 FROM $build_image AS build-stage
 
-RUN apt-get update && apt-get install bzip2 libssl-dev --yes
-
-# build static libmnl
-WORKDIR /tmp/libmnl
-RUN curl -sL https://www.netfilter.org/pub/libmnl/libmnl-1.0.5.tar.bz2 | tar jx --strip-components=1 && \
-  ./configure --enable-static --disable-shared --prefix=/usr && \
-  make -j CFLAGS="-fPIE -O3" && \
-  make install
-
-# build static libnftnl
-WORKDIR /tmp/libnftnl
-RUN curl -sL https://www.netfilter.org/pub/libnftnl/libnftnl-1.2.3.tar.bz2 | tar jx --strip-components=1 && \
-  ./configure --enable-static --disable-shared --prefix=/usr && \
-  make -j CFLAGS="-fPIE -O3" && \
-  make install
-
-# build static nftables
-WORKDIR /tmp/nftables
-RUN curl -sL https://www.netfilter.org/pub/nftables/nftables-1.0.5.tar.bz2 | tar jx --strip-components=1 && \
-  ./configure --enable-static --disable-shared --with-mini-gmp --without-cli --prefix=/usr --disable-python && \
-  make -j CFLAGS="-fPIE -O3" && \
-  make install
+# Link against the distribution's libnftables rather than statically bundling
+# a pinned build. The bundled versions (nftables 1.0.5 / libnftnl 1.2.3 /
+# libmnl 1.0.5, pinned in 2022) segfault on Ubuntu 26.04, which ships nftables
+# 1.1.6: nft_run_cmd_from_buffer crashes as soon as it parses a ruleset created
+# by the newer userspace. Using the distro package keeps the linked library in
+# step with the nftables that is actually installed on the host.
+RUN apt-get update && apt-get install bzip2 libssl-dev libnftables-dev libnftnl-dev libmnl-dev --yes
 
 WORKDIR /tmp/sparoid
 # Copy all files


### PR DESCRIPTION
## Problem

`sparoid-server` segfaults on Ubuntu 26.04 as soon as it handles a knock, on any host with a real nftables ruleset loaded. Because sparoid gates SSH, this locks you out of the box entirely:

```
Invalid memory access (signal 11) at address 0x0
[0x...] ?? in sparoid-server
[0x...] ?? in linux-vdso.so.1
[0x0] ???
sparoid-server.service: Main process exited, code=exited, status=11/n/a
```

## Root cause

`deb.dockerfile` statically bundled **nftables 1.0.5 / libnftnl 1.2.3 / libmnl 1.0.5**, pinned in #0b1f739 back in 2022. Ubuntu 26.04 ships **nftables 1.1.6**, so `nft_run_cmd_from_buffer` crashes while parsing a ruleset created by the much newer userspace.

`f76f5e8` added `ubuntu-26.04` to the deb matrix but left those pins untouched, so the resulting package builds and installs fine and then dies at runtime.

The reason this slipped through: it only reproduces when the `sparoid`/`sparoid6` sets **actually exist**. With no ruleset loaded the same call fails gracefully and the server survives — so a bare container test looks healthy.

| Ruleset present | Result |
|---|---|
| No (`sparoid6` missing) | Graceful error, server survives |
| **Yes** (production `nftables.conf`) | **SIGSEGV on first knock** |

## Fix

Install `libnftables-dev`, `libnftnl-dev` and `libmnl-dev` and link against them, so the linked library always matches the nftables actually installed on the host. `dpkg-shlibdeps` now picks this up automatically:

```
Depends: ..., libnftables1 (>= 1.0.2), ...
```

This also brings the deb in line with the rest of the repo — `rpm.dockerfile` already uses `nftables-devel`, `Dockerfile` uses `nftables-dev`, and `tar.dockerfile` builds `-Dwithout_nftables`. The deb was the only outlier still bundling its own.

## Verification

Built the deb for both `ubuntu-24.04` and `ubuntu-26.04`, loaded the production `nftables.conf`, and sent real knocks with the `sparoid` client:

- **Before**, on 26.04: died with `signal 11` on the very first packet.
- **After**, on 26.04 and 24.04: three knocks accepted, no crash, and the sets are populated —
  ```
  [::1]:60505 packet accepted ip=0000:...:0001
  elements = { ::1 expires 1s887ms }
  ```

Also ruled out along the way: the Crystal message/packet code (IPv4, IPv6 and IPv4-mapped packets all parse correctly), the machines-side `sparoid.ini`, and the host images / chrony-timesyncd — the crash reproduces in a plain `ubuntu:26.04` container.

## Note

Left the netfilter version pins deleted rather than bumped. Upstream `netfilter.org/pub/nftables/` only publishes up to 1.0.5, so there is no newer tarball to pin to — tracking the distro package is the durable fix.