### PR TITLE
Build deb with -Dwithout_nftables instead of linking libnftables

### DIFF
--- a/build/deb
+++ b/build/deb
@@ -7,8 +7,8 @@ pkg_version=${1:-$(shards version)}
 pkg_revision=${2:-1}
 architecture=${3:-$(dpkg --print-architecture)}
 
-shards build --production --release --no-debug sparoid-server
-shards build --production --release --no-debug -Dgc_none sparoid
+shards build --production --release --no-debug -Dwithout_nftables sparoid-server
+shards build --production --release --no-debug -Dgc_none -Dwithout_nftables sparoid
 strip bin/*
 
 # dpkg-shlibdeps requires presence of `debian/control`
@@ -115,6 +115,7 @@ Section: net
 Priority: optional
 Architecture: $architecture
 Depends: $depends
+Recommends: nftables
 Installed-Size: $(du -ks usr/ | cut -f 1)
 Maintainer: 84codes <contact@84codes.com>
 Description: Single Packet Authorization

--- a/deb.dockerfile
+++ b/deb.dockerfile
@@ -3,27 +3,6 @@ FROM $build_image AS build-stage
 
 RUN apt-get update && apt-get install bzip2 libssl-dev --yes
 
-# build static libmnl
-WORKDIR /tmp/libmnl
-RUN curl -sL https://www.netfilter.org/pub/libmnl/libmnl-1.0.5.tar.bz2 | tar jx --strip-components=1 && \
-  ./configure --enable-static --disable-shared --prefix=/usr && \
-  make -j CFLAGS="-fPIE -O3" && \
-  make install
-
-# build static libnftnl
-WORKDIR /tmp/libnftnl
-RUN curl -sL https://www.netfilter.org/pub/libnftnl/libnftnl-1.2.3.tar.bz2 | tar jx --strip-components=1 && \
-  ./configure --enable-static --disable-shared --prefix=/usr && \
-  make -j CFLAGS="-fPIE -O3" && \
-  make install
-
-# build static nftables
-WORKDIR /tmp/nftables
-RUN curl -sL https://www.netfilter.org/pub/nftables/nftables-1.0.5.tar.bz2 | tar jx --strip-components=1 && \
-  ./configure --enable-static --disable-shared --with-mini-gmp --without-cli --prefix=/usr --disable-python && \
-  make -j CFLAGS="-fPIE -O3" && \
-  make install
-
 WORKDIR /tmp/sparoid
 # Copy all files
 COPY shard.yml shard.lock README.md LICENSE ./


### PR DESCRIPTION
## Problem

`sparoid-server` segfaults on Ubuntu 26.04 on the first knock, on any host with a real nftables ruleset loaded. Since sparoid might gate SSH, this can lock you out of the box:

```
Invalid memory access (signal 11) at address 0x0
[0x...] ?? in sparoid-server
[0x...] ?? in linux-vdso.so.1
[0x0] ???
sparoid-server.service: Main process exited, code=exited, status=11/n/a
```

The deb statically bundled **nftables 1.0.5 / libnftnl 1.2.3 / libmnl 1.0.5**, pinned in `0b1f739` (2022). Ubuntu 26.04 ships **nftables 1.1.6**; the ABI moved, so `nft_run_cmd_from_buffer` dereferences a null pointer while parsing a ruleset built by the newer userspace.

It only reproduces when the `sparoid`/`sparoid6` sets **actually exist** — with no ruleset loaded the call fails gracefully, which is why CI never caught it.

## Why not just link the distro libnftables (#25)

That fixes it today, and it is the smaller change. But `libnftables` keeps the **same SONAME across the entire range**:

| distro | version | soname |
|---|---|---|
| debian 11 | 0.9.8 | `libnftables.so.1` |
| ubuntu 22.04 | 1.0.2 | `libnftables.so.1` |
| debian 12 | 1.0.6 | `libnftables.so.1` |
| ubuntu 24.04 | 1.0.9 | `libnftables.so.1` |
| ubuntu 26.04 | 1.1.6 | `libnftables.so.1` |

So `Depends: libnftables1 (>= 1.0.2)` is a floor with no ceiling, and the mechanism that normally blocks an ABI-incompatible swap never fires. A future upgrade could segfault the gatekeeper again. On our own servers `apt-mark hold nftables` happens to pin the library too (`nftables` declares `Depends: libnftables1 (= <exact version>)`), but that is a CloudAMQP deployment detail — it does not protect anyone else running sparoid.

## This change

Build with `-Dwithout_nftables`, which already exists in `src/nftables.cr` and is already used by `tar.dockerfile`. It calls the `nft` binary instead of linking `libnftables`:

```crystal
Process.run("nft", {cmd}, ...)
status.success? || raise Error.new("nftables command '#{cmd}' failed")
```

The interface becomes a command string plus an exit code rather than struct layouts shared in one address space, so there is no ABI to break. `nft` parses the command in its own process against its own matching library. A version mismatch can then only mean a non-zero exit, which is logged while the server keeps serving — instead of killing the process that gates SSH.

### Recommends, not Depends

`nftables` is a `Recommends`. `dpkg-shlibdeps` cannot infer it (nothing is linked), so it has to be declared by hand — but the default shipped `sparoid.ini` uses **iptables** via `open-cmd`, and `server-cli.cr` falls back to `open-cmd`/`close-cmd` whenever no `nftables-cmd` is set. A hard `Depends` would force nftables onto users running iptables, ufw or anything else. `Recommends` installs it by default and can be declined.

## Verification

Built the deb for `ubuntu-26.04`, `ubuntu-24.04` and `debian-11`, loaded the production `nftables.conf`, and sent real knocks with the `sparoid` client:

| host nft | result |
|---|---|
| 1.1.6 (ubuntu 26.04) | 3 knocks accepted, set populated |
| 1.0.9 (ubuntu 24.04) | 3 knocks accepted, set populated |
| 0.9.8 (debian 11) | 3 knocks accepted, set populated |

```
[::1]:37546 packet accepted ip=0000:0000:0000:0000:0000:0000:0000:0001
elements = { ::1 expires 1s905ms }
```

Also confirmed:

- `ldd` on the binary links **no** nftables/nftnl/mnl libraries at all.
- Default `apt install` pulls in `nft` via `Recommends`.
- `apt install --no-install-recommends` leaves `nft` out, and `sparoid-server` still starts and runs on the iptables `open-cmd` path.
- The graceful failure mode is real: with the sets missing, the server logs `ERROR: nftables command '...' failed` per knock and stays up, where the linked build died with signal 11.

Ruled out along the way: the Crystal message/packet code (IPv4, IPv6 and IPv4-mapped all parse correctly), the machines-side `sparoid.ini`, and the host images / chrony-timesyncd — the crash reproduces in a plain `ubuntu:26.04` container.

## Trade-offs vs #25

- One `fork`/`exec` per knock. Negligible here — the ruleset already rate-limits port 8484 to 1/second per source.
- Errors are an exit status plus stderr rather than a structured return. In practice `nft` prints the same message the library did.
- Requires the `nft` binary on PATH, hence the `Recommends`.

In exchange, a host library upgrade cannot segfault the gatekeeper.