### PR TITLE
2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.3] - 2026-08-13
+- Fix `sparoid-server` segfault on Ubuntu 26.04: the deb no longer statically bundles nftables 1.0.5 / libnftnl 1.2.3 / libmnl 1.0.5, but links against the distribution's libnftables so the linked library matches the nftables installed on the host
+- Deb now depends on `libnftables1`, picked up automatically by `dpkg-shlibdeps`
+- CI: unbreak the Lint/Ameba job, which failed to build ameba against current Crystal
+
 ## [2.0.2] - 2026-05-06
 - Client: warn (instead of error) on per-address UDP send failures when at least one address succeeds, so dual-stack hosts on single-family networks no longer log catastrophically
 - Client: raise `Sparoid::Client::SendError` when every address fails, surfacing a clear actionable failure

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: sparoid
-version: 2.0.2
+version: 2.0.3
 
 authors:
   - 84codes <contact@84codes.com>


### PR DESCRIPTION
Release 2.0.3. Bumps `shard.yml` and adds the CHANGELOG entry — no code changes.

Rebased onto `main` after #28 merged, so this is now a single commit on top of `05da2be`.

## What's in the release

Two changes since 2.0.2:

- **#25** — fixes the `sparoid-server` segfault on Ubuntu 26.04 by linking the deb against the distribution's libnftables instead of statically bundling nftables 1.0.5 / libnftnl 1.2.3 / libmnl 1.0.5. Since sparoid gates SSH, that crash locked you out of the host entirely, so this is worth getting onto packagecloud promptly.
- **#28** — unbreaks the `Lint/Ameba` CI job, which had been failing on `main` and gating the package builds.

## Verification

Verified the merged #25 build on arm64:

| Host | nftables | `ldd` shows `libnftables.so.1` |
|---|---|---|
| Ubuntu 22.04 (jammy) | 1.0.2 | yes |
| Ubuntu 24.04 (noble) | 1.0.6 | yes |

Both link dynamically and resolve to real paths under `/lib/aarch64-linux-gnu/`, confirming `dpkg-shlibdeps` picks up `libnftables1`. The pre-#25 package shows no `libnftables` line at all, since it bundled its own.

Note these two hosts confirm the linkage change and that older distros still install cleanly — they do not exercise the segfault itself, as 1.0.2/1.0.6 are too close to the bundled 1.0.5 to trigger it. That path was verified on 26.04 in #25.

## Known flake in the spec suite

`spec/sparoid_spec.cr` asserts immediately after a single `Fiber.yield`, which does not guarantee the server fiber has consumed the datagram. This **does** hit CI on Linux — #28 saw `Spec` fail at `spec/sparoid_spec.cr:91` (`works with two keys`, `Expected: 2, got: 1`, seed 70177) and then pass on a re-run with no code change, so it is a coin flip rather than a platform issue.

Because `deb`/`rpm`/`docker`/`tar` all declare `needs: [spec, format, lint]`, a red `Spec` skips every package job and blocks publication. If that happens here, re-run the failed jobs.

Separately, `spec/sparoid_spec.cr:97` fails on macOS: it sends to `0.0.0.0` as a UDP *destination*, which is valid to bind but not to send to — Linux routes it to loopback so CI passes, macOS returns `EHOSTUNREACH`.

Both were deliberately left out of #28 to keep it scoped to the CI fix. A working fix for both exists at `e4991d34` (30/30 randomized runs green, all package jobs passing) if we want to pick it up in a follow-up.

## After merge

Publication to packagecloud is tag-gated (`if: startsWith(github.ref, 'refs/tags/v')`), so merging this does not publish anything on its own — it needs a `v2.0.3` tag pushed afterwards.

Two of my test hosts have a hand-installed `2.0.2-1` deb that collides with the published version; they will need `apt-mark unhold sparoid` before they can pick up 2.0.3.