### PR TITLE
Unbreak the Lint/Ameba CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Shards install
         run: shards install
-      - name: Spec
-        run: bin/ameba --no-color
+      - name: Build ameba
+        run: cd lib/ameba && shards build ameba
+      - name: Ameba
+        run: lib/ameba/bin/ameba --no-color
   docker:
     name: Docker container
     needs: [spec, format, lint]

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.6.1
+    version: 1.7.0-dev+git.commit.f53fcd3382553121239c8f144aec5e27aeadbed8
 
   fdpass:
     git: https://github.com/84codes/fdpass.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -17,6 +17,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+    commit: f53fcd3382553121239c8f144aec5e27aeadbed8
 
 crystal: 1.19.1
 

--- a/src/client.cr
+++ b/src/client.cr
@@ -31,7 +31,7 @@ module Sparoid
           end
         end
       end
-      self.new(key, hmac_key)
+      new(key, hmac_key)
     end
 
     def initialize(@key : String, @hmac_key : String)


### PR DESCRIPTION
`Lint/Ameba` is red on `main` (run 31693050967) and blocks #27 — `deb`/`rpm`/`docker`/`tar` all declare `needs: [spec, format, lint]`, so 2.0.3 cannot publish to packagecloud until this is green.

## Problem

Ameba's postinstall can't compile:

```
I: Postinstall of ameba: shards build -Dpreview_mt
E: Failed postinstall of ameba on shards build -Dpreview_mt:
Error: undefined method 'next_string_array_token' for Crystal::Lexer
```

Two independent breakages against current Crystal: `Crystal::Lexer#next_string_array_token` was removed from the compiler API ameba's tokenizer uses, and `-Dpreview_mt` is now deprecated. `bin/ameba` is never produced, so the job exits non-zero.

The `Spec` job is unaffected because it runs `shards install --production`, which skips `development_dependencies` — ameba is the only one. So this is a lint-only failure; specs have been passing throughout.

## Fix

**Bumping to the latest tag does not work.** Upstream fixed both issues (a `responds_to?` guard for the lexer call, and dropping `-Dpreview_mt`) but neither is in any release — 1.6.2, 1.6.3 and 1.6.4 all still carry the broken call. The fix exists only on `master` / the `v1.7.0-dev` prerelease tag, so this pins commit `f53fcd3`.

Pinning also drops ameba's `postinstall`, so CI now builds it explicitly before running it.

The newer ameba adds `Style/RedundantSelf`, which flags `self.new` inside `def self.from_ini` at `src/client.cr:34`. Fixed; behavior-identical, since `new` resolves the same way in that scope.

## Verification

- `lib/ameba/bin/ameba`: 15 inspected, 0 failures
- `crystal tool format --check`: clean
- `shards install --production` (the `Spec` job's path) still resolves

Not verified in the CI container itself — Docker wasn't running locally, so the Alpine build of pinned ameba is unproven until CI runs on this PR. Worth checking the Lint job here before merging, since that's the whole point.

## Follow-up

Pinning a `master` commit of a linter is a bit-rot trade, not a durable fix — worth moving to `~> 1.7.0` once it's tagged. The root cause is the unpinned `84codes/crystal:latest-alpine` base image, which will keep producing this class of break as Crystal moves.

Separately, and left alone here per review: the spec suite fails on macOS (`client can send another IP` sends to `0.0.0.0`, valid to bind but not to send to — Linux routes it to loopback so CI passes, macOS returns `EHOSTUNREACH`) and flakes roughly 1 in 12 randomized runs on a `Fiber.yield` race in all nine server specs. Neither affects CI.